### PR TITLE
Fix for 'put' command

### DIFF
--- a/src/soul.eg
+++ b/src/soul.eg
@@ -80,7 +80,7 @@ def primitives = {
     ("to_int", prim_to_int), ("to_text", prim_to_text) }
 
 def fetch = [ 0 {X|_} -> X | N {_|XX} -> fetch (N - 1) XX | _ _ -> throw boom ]
-def put = [ 0 X {_,SS} -> {X|SS} | N X {S|SS} -> {S| put (N - 1) X SS} | _ _ _ -> throw boom ]
+def put = [ 0 X {_|SS} -> {X|SS} | N X {S|SS} -> {S| put (N - 1) X SS} | _ _ _ -> throw boom ]
 def delete = [ 0 {_|SS} -> SS | N {S|SS} -> {S|delete (N - 1) SS} | _ _ -> throw boom ]
 def swap = [ {A,B|SS} -> {B,A|SS} | _ -> throw boom ]
 


### PR DESCRIPTION
I believe there was a typo in the definition of the `put` word, which had the side effect of making the `put` command only work if the destination was the second-from-the-bottom element on the stack. This PR fixes the typo.